### PR TITLE
Check file existence before unlinking it

### DIFF
--- a/index.js
+++ b/index.js
@@ -309,7 +309,7 @@ module.exports = class Filter extends Plugin {
         result = await this.processAndCacheFile(srcDir, destDir, entry, forceInvalidation, isChange, stats);
       } else {
         stats.linked++;
-        if (isChange) {
+        if (isChange && fs.existsSync(outputPath)) {
           fs.unlinkSync(outputPath);
         }
         result = symlinkOrCopySync(srcPath, outputPath);


### PR DESCRIPTION
Check whether a file exists before unlinking it. Unlinking a non-existing file will throw an error message. See ClarkSource/ember-makeup#242

Dunno if this is the correct way of fixing the original linked issue - yet I also think this is not a wrong way to do so.