### PR TITLE
mark some options as optional

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -131,8 +131,8 @@ interface Options {
   inputEncoding?: string;
   outputEncoding?: string;
   async?: boolean;
-  dependencyInvalidation: boolean;
-  concurrency: number;
+  dependencyInvalidation?: boolean;
+  concurrency?: number;
 }
 
 abstract class Filter extends Plugin {


### PR DESCRIPTION
This PR fixes: #194 to mark `dependencyInvalidation` and `concurrency` as optional options as well.