### PR TITLE
Handle case where there's a cached dependencies object, but no dependencies.

### DIFF
--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -387,7 +387,8 @@ class Dependencies {
    */
   static deserialize(dependencyData: Dependencies.SerializedDependencies, customFS: Dependencies.FSFacade, inputEncoding: string): Dependencies {
     let dependencies = new Dependencies(customFS, inputEncoding);
-    if (typeof dependencyData.fsTrees[0].fsRoot === 'string') {
+    let prevFsTree = dependencyData.fsTrees[0];
+    if (prevFsTree && typeof prevFsTree.fsRoot === 'string') {
       // Ideally the serialized cache would be invalidated when this code changes,
       // but just to be safe we handle the situation where old serialized data
       // that doesn't work with the current implementation might be present.

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -392,6 +392,7 @@ class Dependencies {
       // Ideally the serialized cache would be invalidated when this code changes,
       // but just to be safe we handle the situation where old serialized data
       // that doesn't work with the current implementation might be present.
+      dependencies.seal();
       return dependencies;
     }
     let files = Object.keys(dependencyData.dependencies);


### PR DESCRIPTION
This is a subtle bug that has a work-around (add a file that's a dependency, clear the cache) but it really messes up the "Getting Started" experience when working with a new addon that uses dependencies.