### PR TITLE
[docs] removes prototype examples and uses classes instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,6 @@ likely the name of the plugin, its version and the actual versions of its depend
 const Filter = require('broccoli-persistent-filter');
 
 class Subclass extends Filter {
-  constructor(inputNode, search, replace, options = {}) {
-    super(inputNode, {
-      annotation: options.annotation
-    });
-  }
-
   cacheKey() {
     return md5(Filter.prototype.call(this) + inputOptionsChecksum + dependencyVersionChecksum);
   }
@@ -175,12 +169,6 @@ files that have dependencies that affect the output.
 const Filter = require('broccoli-persistent-filter');
 
 class Subclass extends Filter {
-  constructor(inputNode, search, replace, options = {}) {
-    super(inputNode, {
-      annotation: options.annotation
-    });
-  }
-
   cacheKeyProcessString(string, relativePath) {
     return superAwesomeDigest(string);
   }

--- a/README.md
+++ b/README.md
@@ -146,8 +146,18 @@ It is configured by subclassing and refining `cacheKey` method. A good key here,
 likely the name of the plugin, its version and the actual versions of its dependencies.
 
 ```js
-Subclass.prototype.cacheKey = function() {
- return md5(Filter.prototype.call(this) + inputOptionsChecksum + dependencyVersionChecksum);
+const Filter = require('broccoli-persistent-filter');
+
+class Subclass extends Filter {
+  constructor(inputNode, search, replace, options = {}) {
+    super(inputNode, {
+      annotation: options.annotation
+    });
+  }
+
+  cacheKey() {
+    return md5(Filter.prototype.call(this) + inputOptionsChecksum + dependencyVersionChecksum);
+  }
 }
 ```
 
@@ -162,8 +172,18 @@ for rebuilds. See the `dependencyInvalidation` option above to invalidate
 files that have dependencies that affect the output.
 
 ```js
-Subclass.prototype.cacheKeyProcessString = function(string, relativePath) {
-  return superAwesomeDigest(string);
+const Filter = require('broccoli-persistent-filter');
+
+class Subclass extends Filter {
+  constructor(inputNode, search, replace, options = {}) {
+    super(inputNode, {
+      annotation: options.annotation
+    });
+  }
+
+  cacheKeyProcessString(string, relativePath) {
+    return superAwesomeDigest(string);
+  }
 }
 ```
 


### PR DESCRIPTION
# Motivation

Moving the examples to show the class based approach will help keep the docs uniform in what we are suggesting people do.